### PR TITLE
Create Rake Task for Batch Insert of Google Products

### DIFF
--- a/app/models/spree/google_shopping_integration.rb
+++ b/app/models/spree/google_shopping_integration.rb
@@ -10,6 +10,8 @@ class Spree::GoogleShoppingIntegration < ActiveRecord::Base
   validates :target_country, presence: true
   validates :active, presence: true
   
+  scope :active, -> { where(active: true) }
+  
   def self.channel_options
     CHANNELS
   end

--- a/app/services/spree/insert_products_collection_to_google_shopping.rb
+++ b/app/services/spree/insert_products_collection_to_google_shopping.rb
@@ -8,7 +8,7 @@ module Spree
       @google_shopping_items = GoogleShoppingItem.wrap(variants)
       @google_shopping_integration = google_shopping_integration
       entries = @google_shopping_items.map { |item| bulk_attributes(item) }
-      google_shopping_client.batch_operation(entries)
+      success?(google_shopping_client.batch_operation(entries))
     end
     
     private
@@ -33,6 +33,10 @@ module Spree
     
     def self.route_helpers
       Spree::Core::Engine.routes.url_helpers
+    end
+    
+    def self.success?(message)
+      message.response.status == 200
     end
   end
 end

--- a/app/services/spree/insert_variant_to_google_shopping.rb
+++ b/app/services/spree/insert_variant_to_google_shopping.rb
@@ -5,7 +5,7 @@ module Spree
       @variant = variant
       @google_shopping_item = GoogleShoppingItem.new(@variant)
       @google_shopping_integration = google_shopping_integration
-      google_shopping_client.insert(base_attributes.merge(@google_shopping_item.to_request))
+      success?(google_shopping_client.insert(base_attributes.merge(@google_shopping_item.to_request)))
     end
     
     private
@@ -25,6 +25,10 @@ module Spree
     
     def self.route_helpers
       Spree::Core::Engine.routes.url_helpers
+    end
+    
+    def self.success?(message)
+      message.response.status == 200
     end
   end
 end

--- a/lib/spree_google_shopping.rb
+++ b/lib/spree_google_shopping.rb
@@ -1,3 +1,6 @@
 require 'spree_core'
 require 'spree_google_shopping/engine'
 require 'spree_google_shopping/client'
+if defined?(Rails::Railtie)
+  require 'spree_google_shopping/railtie'
+end

--- a/lib/spree_google_shopping/railtie.rb
+++ b/lib/spree_google_shopping/railtie.rb
@@ -1,0 +1,9 @@
+module SpreeGoogleShopping
+  class Railtie < ::Rails::Railtie
+    
+    rake_tasks do
+      load 'spree_google_shopping/tasks.rb'
+    end
+    
+  end
+end

--- a/lib/spree_google_shopping/tasks.rb
+++ b/lib/spree_google_shopping/tasks.rb
@@ -1,0 +1,12 @@
+namespace :spree_google_shopping do
+  task bulk_insert: :environment do
+    Spree::GoogleShoppingIntegration.active.each do |integration|
+      puts "Inserting products for #{integration.name}"
+      begin
+        Spree::InsertProductsCollectionToGoogleShopping.call(integration.products, integration)
+      rescue StandardError => e
+        puts "Failed to import due to exceptions: #{e.message}"
+      end
+    end
+  end
+end

--- a/lib/spree_google_shopping/tasks.rb
+++ b/lib/spree_google_shopping/tasks.rb
@@ -3,9 +3,13 @@ namespace :spree_google_shopping do
     Spree::GoogleShoppingIntegration.active.each do |integration|
       puts "Inserting products for #{integration.name}"
       begin
-        Spree::InsertProductsCollectionToGoogleShopping.call(integration.products, integration)
+        if Spree::InsertProductsCollectionToGoogleShopping.call(integration.products, integration)
+          puts "-- Success!"
+        else
+          puts "The server returned an error when attempting to insert"
+        end
       rescue StandardError => e
-        puts "Failed to import due to exceptions: #{e.message}"
+        puts "Failed to insert due to exceptions: #{e.message}"
       end
     end
   end


### PR DESCRIPTION
This creates a rake task that loops through active Spree Google Shopping Integrations and their products, batch inserting them into the Google Shopping Service. The task can be run by calling:

```
bundle exec rake spree_google_shopping:bulk_insert
```

Fixes #4 
