### PR TITLE
Fix gs_color method by moving it AR attribute

### DIFF
--- a/app/models/spree/google_shopping_item.rb
+++ b/app/models/spree/google_shopping_item.rb
@@ -5,7 +5,6 @@ module Spree
       gs_additional_image_links
       gs_availability
       gs_availability_date
-      gs_color
       gs_description
       gs_google_product_category
       gs_identifier_exists
@@ -22,6 +21,7 @@ module Spree
       gs_adwords_redirect
       gs_age_group
       gs_brand
+      gs_color
       gs_condition
       gs_gender
       gs_gtin
@@ -65,10 +65,6 @@ module Spree
     
     def gs_availability_date
       product.available_on.try(:iso8601)
-    end
-    
-    def gs_color
-      product.product_properties.where(property_id: Spree::Product.color_property_id).pluck(:value).first
     end
     
     def gs_description

--- a/app/views/spree/admin/variants/_google_shopping_data_fields.html.erb
+++ b/app/views/spree/admin/variants/_google_shopping_data_fields.html.erb
@@ -86,6 +86,10 @@
         <%= f.label :gs_pattern, Spree.t(:gs_pattern) %>
         <%= f.text_field :gs_pattern, :class => 'fullwidth' %>
       </div>
+      <div class="field" data-hook="gs_color"> 
+        <%= f.label :gs_color, Spree.t(:gs_color) %>
+        <%= f.text_field :gs_color, :class => 'fullwidth' %>
+      </div>
     </div>
   </div>
 </fieldset>

--- a/db/migrate/20150128202726_add_google_shopping_attributes_to_spree_variants.rb
+++ b/db/migrate/20150128202726_add_google_shopping_attributes_to_spree_variants.rb
@@ -6,6 +6,7 @@ class AddGoogleShoppingAttributesToSpreeVariants < ActiveRecord::Migration
     add_column :spree_variants, :gs_adwords_redirect, :string
     add_column :spree_variants, :gs_age_group, :string
     add_column :spree_variants, :gs_brand, :string
+    add_column :spree_variants, :gs_color, :string
     add_column :spree_variants, :gs_condition, :string
     add_column :spree_variants, :gs_gender, :string
     add_column :spree_variants, :gs_gtin, :string


### PR DESCRIPTION
I accidentally brought in logic specific to one of my other apps for this method. I think it should become a database attribute that can be decorated over in the host app.

Fixes #8
