### PR TITLE
Improvements to Batch Inserts

### DIFF
--- a/app/services/spree/insert_products_collection_to_google_shopping.rb
+++ b/app/services/spree/insert_products_collection_to_google_shopping.rb
@@ -2,7 +2,7 @@ module Spree
   class InsertProductsCollectionToGoogleShopping
     
     def self.call(products, google_shopping_integration)
-      variants = products.includes(:variants, :master, :taxons).flat_map do |p|
+      variants = products.includes(:taxons, master: [:images, :stock_items, :default_price], variants: [:images, :stock_items, :default_price]).flat_map do |p|
         p.variants.any? ? p.variants : p.master
       end
       @google_shopping_items = GoogleShoppingItem.wrap(variants)

--- a/config/initializers/spree_preferences.rb
+++ b/config/initializers/spree_preferences.rb
@@ -1,3 +1,4 @@
 Spree::Preferences::Configuration.class_eval do
   preference :shipping_weight_unit, :string, default: 'lbs'
+  preference :google_shopping_batch_size, :integer, default: 100
 end

--- a/lib/spree_google_shopping/tasks.rb
+++ b/lib/spree_google_shopping/tasks.rb
@@ -1,15 +1,22 @@
 namespace :spree_google_shopping do
   task bulk_insert: :environment do
+    batch_size = Spree::Config.google_shopping_batch_size
     Spree::GoogleShoppingIntegration.active.each do |integration|
       puts "Inserting products for #{integration.name}"
-      begin
-        if Spree::InsertProductsCollectionToGoogleShopping.call(integration.products, integration)
-          puts "-- Success!"
-        else
-          puts "The server returned an error when attempting to insert"
+      product_count = integration.products.count
+      i = 0
+      while (i * batch_size) < product_count 
+        begin
+          puts "-- Batch #{i + 1}"
+          if Spree::InsertProductsCollectionToGoogleShopping.call(integration.products.limit([i, batch_size].join(',')), integration)
+            puts "-- Success!"
+          else
+            puts "The server returned an error when attempting to insert"
+          end
+        rescue StandardError => e
+          puts "Failed to insert due to exceptions: #{e.message}"
         end
-      rescue StandardError => e
-        puts "Failed to insert due to exceptions: #{e.message}"
+        i += 1
       end
     end
   end


### PR DESCRIPTION
- Eager loads more attributes for variants to speed up processing (#12)
- Inserts products in batches, since Google Shopping API limits request sizes to 1MB (#13)
  - Batch size can be configured via `Spree::Config.google_shopping_batch_size`
