### PR TITLE
Allow scoping by taxons

### DIFF
--- a/app/assets/javascripts/spree/backend/google_shopping_integrations_taxons_autocomplete.js.coffee
+++ b/app/assets/javascripts/spree/backend/google_shopping_integrations_taxons_autocomplete.js.coffee
@@ -1,0 +1,29 @@
+$ ->
+  if $('#google_shopping_integration_taxon_ids').length > 0
+    $('#google_shopping_integration_taxon_ids').select2 
+      placeholder: Spree.translations.taxon_placeholder
+      multiple: true
+      initSelection: (element, callback) -> 
+        url = Spree.url Spree.routes.taxons_search, { ids: element.val() }
+        $.getJSON url, null, (data) ->
+          callback data['taxons']
+      ajax: 
+        url: Spree.routes.taxons_search
+        datatype: 'json'
+        data: (term, page) ->
+          per_page: 50,
+          page: page,
+          q: {
+            name_cont: term
+          },
+          token: Spree.api_key
+        results: (data, page) ->
+          more = page < data.pages
+          {
+            results: data['taxons'],
+            more: more
+          }
+      formatResult: (taxon) ->
+        taxon.pretty_name
+      formatSelection: (taxon) ->
+        taxon.pretty_name

--- a/app/assets/javascripts/spree/backend/spree_google_shopping.js
+++ b/app/assets/javascripts/spree/backend/spree_google_shopping.js
@@ -1,0 +1,1 @@
+//= require ./google_shopping_integrations_taxons_autocomplete

--- a/app/models/spree/google_shopping_integration.rb
+++ b/app/models/spree/google_shopping_integration.rb
@@ -3,6 +3,8 @@ class Spree::GoogleShoppingIntegration < ActiveRecord::Base
   
   belongs_to :products_scope, polymorphic: true
   
+  has_and_belongs_to_many :taxons
+  
   validates :name, presence: true
   validates :merchant_id, presence: true
   validates :channel, presence: true, inclusion: { in: CHANNELS }

--- a/app/models/spree/google_shopping_integration.rb
+++ b/app/models/spree/google_shopping_integration.rb
@@ -19,7 +19,7 @@ class Spree::GoogleShoppingIntegration < ActiveRecord::Base
   end
   
   def products
-    products_scope.try(:products) || Spree::Product.all
+    scoped_by_taxons(products_scope.try(:products) || Spree::Product.all)
   end
   
   def client
@@ -29,5 +29,15 @@ class Spree::GoogleShoppingIntegration < ActiveRecord::Base
         dryRun: test?
       }
     )
+  end
+  
+  private
+  
+  def scoped_by_taxons(products)
+    if taxons.any? 
+      products.includes(:taxons).where(spree_taxons: { id: taxons })
+    else
+      products
+    end
   end
 end

--- a/app/views/spree/admin/google_shopping_integrations/_form.html.erb
+++ b/app/views/spree/admin/google_shopping_integrations/_form.html.erb
@@ -56,6 +56,13 @@
         </li>
       </ul>
     </div>
+    
+    <div data-hook="admin_product_form_taxons">
+      <%= field_container :google_shopping_integration, :taxons do %>
+        <%= label :google_shopping_integration, :taxon_ids, Spree.t(:taxons) %><br />
+        <%= hidden_field :google_shopping_integration, :taxon_ids, :value => @object.taxon_ids.join(',') %>
+      <% end %>
+    </div>
   </div>
   
   <div class="clear"></div>

--- a/db/migrate/20150209154938_create_spree_google_shopping_integrations_taxons.rb
+++ b/db/migrate/20150209154938_create_spree_google_shopping_integrations_taxons.rb
@@ -1,0 +1,10 @@
+class CreateSpreeGoogleShoppingIntegrationsTaxons < ActiveRecord::Migration
+  def change
+    create_table :spree_google_shopping_integrations_taxons do |t|
+      t.integer :google_shopping_integration_id
+      t.integer :taxon_id
+    end
+    
+    add_index(:spree_google_shopping_integrations_taxons, [:google_shopping_integration_id, :taxon_id], unique: true, name: 'google_shopping_integrations_taxons_index')
+  end
+end

--- a/lib/generators/spree_google_shopping/install/install_generator.rb
+++ b/lib/generators/spree_google_shopping/install/install_generator.rb
@@ -5,6 +5,7 @@ module SpreeGoogleShopping
       class_option :auto_run_migrations, :type => :boolean, :default => false
 
       def add_javascripts
+        append_file 'vendor/assets/javascripts/spree/backend/all.js', "//= require spree/backend/spree_google_shopping\n"
       end
 
       def add_stylesheets

--- a/spec/models/spree/google_shopping_integration_spec.rb
+++ b/spec/models/spree/google_shopping_integration_spec.rb
@@ -3,6 +3,12 @@ require 'spec_helper'
 describe Spree::GoogleShoppingIntegration do
   subject { build_stubbed :google_shopping_integration }
   
+  it 'has many taxons' do
+    expect(
+      described_class.reflect_on_all_associations(:has_and_belongs_to_many).map(&:name)
+    ).to include(:taxons)
+  end
+  
   context 'Validations' do
     it 'has a valid factory' do
       expect(subject).to be_valid
@@ -61,6 +67,19 @@ describe Spree::GoogleShoppingIntegration do
       it 'returns all products' do
         expect(Spree::Product).to receive(:all)  
         subject.products  
+      end
+    end
+    
+    context 'when the integration has taxons' do
+      let(:taxons) { create_list(:taxon, 2, products: create_list(:product, 2)) }
+      before(:each) do 
+        subject.taxons = taxons 
+      end
+      
+      it 'scopes by taxons' do
+        loose_products = create_list(:product, 2)
+        expect(subject.products).to_not be_empty
+        expect(subject.products & loose_products).to be_empty
       end
     end
   end


### PR DESCRIPTION
This allows an admin to choose a collection of taxons to scope the products for a google shopping integration. Some may want to only upload certain products to certain google shopping storefronts.

Fixes #15
